### PR TITLE
fix bug: stop adding eventKey over and over again

### DIFF
--- a/src/WorkflowGuiBundle/Resources/public/js/workflow/item.js
+++ b/src/WorkflowGuiBundle/Resources/public/js/workflow/item.js
@@ -638,7 +638,9 @@ pimcore.plugin.workflowgui.item = Class.create({
         });
 
         for(var eventKey in events) {
-            events[eventKey].splice(0, 0, eventKey);
+            if(events[eventKey][0] !== eventKey) {
+                events[eventKey].splice(0, 0, eventKey);
+            }
         }
 
         var eventsStore = new Ext.data.ArrayStore({


### PR DESCRIPTION
Before this fix the code added the eventKey to the first array position again and again when clicking the edit icon for an action. Now the code checks if the first position of the array already is the eventKey (when a callback function was defined before).